### PR TITLE
Update sodiumoxide.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ license      = "GPL-3.0"
 byteorder   = ">  0.2.0"
 cbor-codec  = ">= 0.1.0"
 libc        = ">  0.1.0"
-sodiumoxide = ">= 0.0.9"
+
+[dependencies.sodiumoxide]
+version = ">= 0.0.12"
+default-features = false
 
 [dependencies.hkdf]
 git = "https://github.com/wireapp/hkdf"


### PR DESCRIPTION
Do not include default features. Otherwise we pull in `serde` as an
unnecessary dependency.