### PR TITLE
Fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,10 @@ repository   = "git@github.com:wireapp/proteus.git"
 license      = "GPL-3.0"
 
 [dependencies]
-byteorder   = ">  0.2.0"
-cbor-codec  = ">= 0.1.0"
-hkdf        = { git = "https://github.com/wireapp/hkdf", branch = "develop"}
-libc        = ">  0.1.0"
-sodiumoxide = { version = ">= 0.0.12", default-features = false }
+byteorder     = ">  0.2.0"
+cbor-codec    = ">= 0.1.0"
+hkdf          = { git = "https://github.com/wireapp/hkdf", branch = "develop"}
+libc          = ">  0.1.0"
+libsodium-sys = ">= 0.0.12"
+sodiumoxide   = { version = ">= 0.0.12", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,7 @@ license      = "GPL-3.0"
 [dependencies]
 byteorder   = ">  0.2.0"
 cbor-codec  = ">= 0.1.0"
+hkdf        = { git = "https://github.com/wireapp/hkdf", branch = "develop"}
 libc        = ">  0.1.0"
+sodiumoxide = { version = ">= 0.0.12", default-features = false }
 
-[dependencies.sodiumoxide]
-version = ">= 0.0.12"
-default-features = false
-
-[dependencies.hkdf]
-git = "https://github.com/wireapp/hkdf"

--- a/src/internal/derived.rs
+++ b/src/internal/derived.rs
@@ -42,8 +42,8 @@ impl DerivedSecrets {
         let len = Len::new(64).expect("Unexpected hkdf::HASH_LEN.");
         let okm = hkdf(salt, input, info, len);
 
-        ck.as_mut().write_all(&okm[0  .. 32]).unwrap();
-        mk.as_mut().write_all(&okm[32 .. 64]).unwrap();
+        ck.as_mut().write_all(&okm.0[0  .. 32]).unwrap();
+        mk.as_mut().write_all(&okm.0[32 .. 64]).unwrap();
 
         DerivedSecrets {
             cipher_key: CipherKey::new(ck),

--- a/src/internal/keys.rs
+++ b/src/internal/keys.rs
@@ -20,6 +20,7 @@ use cbor::skip::Skip;
 use internal::ffi;
 use internal::types::{DecodeError, DecodeResult, EncodeResult};
 use internal::util::{Bytes64, Bytes32, fmt_hex, opt};
+use libsodium_sys::{self as libsodium};
 use sodiumoxide::crypto::scalarmult as ecdh;
 use sodiumoxide::crypto::sign;
 use sodiumoxide::randombytes;
@@ -374,6 +375,23 @@ impl KeyPair {
 
 // SecretKey ////////////////////////////////////////////////////////////////
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Zero();
+
+// Sodiumoxide's scalarmult function ignores the return code of
+// `crypto_scalarmult_curve25519`, hence we call that function directly.
+// `crypto_scalarmult_curve25519` returns -1 if the resulting value is all 0.
+fn scalarmult(s: &ecdh::Scalar, g: &ecdh::GroupElement) -> Result<ecdh::GroupElement, Zero> {
+    let mut ge = [0; ecdh::GROUPELEMENTBYTES];
+    unsafe {
+        if libsodium::crypto_scalarmult_curve25519(&mut ge, &s.0, &g.0) != 0 {
+            Err(Zero())
+        } else {
+            Ok(ecdh::GroupElement(ge))
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SecretKey {
     sec_edward: sign::SecretKey,
@@ -385,9 +403,8 @@ impl SecretKey {
         Signature { sig: sign::sign_detached(m, &self.sec_edward) }
     }
 
-    pub fn shared_secret(&self, p: &PublicKey) -> [u8; 32] {
-        let ecdh::GroupElement(b) = ecdh::scalarmult(&self.sec_curve, &p.pub_curve);
-        b
+    pub fn shared_secret(&self, p: &PublicKey) -> Result<[u8; 32], Zero> {
+        scalarmult(&self.sec_curve, &p.pub_curve).map(|ge| ge.0)
     }
 
     pub fn encode<W: Write>(&self, e: &mut Encoder<W>) -> EncodeResult<()> {
@@ -405,18 +422,10 @@ impl SecretKey {
                 _ => try!(d.skip())
             }
         }
-        let sec_edward =
-            if let Some(se) = sec_edward {
-                se
-            } else {
-                return Err(DecodeError::MissingField("SecretKey::sec_edward"))
-            };
-        let sec_curve =
-            if let Some(sc) = from_ed25519_sk(&sec_edward).map(ecdh::Scalar) {
-                sc
-            } else {
-                return Err(DecodeError::InvalidField("SecretKey::sec_edward"))
-            };
+        let sec_edward = sec_edward.ok_or(DecodeError::MissingField("SecretKey::sec_edward"))?;
+        let sec_curve  = from_ed25519_sk(&sec_edward)
+            .map(ecdh::Scalar)
+            .map_err(|()| DecodeError::InvalidField("SecretKey::sec_edward"))?;
         Ok(SecretKey {
             sec_edward: sec_edward,
             sec_curve:  sec_curve
@@ -472,18 +481,10 @@ impl PublicKey {
                 _ => try!(d.skip())
             }
         }
-        let pub_edward =
-            if let Some(pe) = pub_edward {
-                pe
-            } else {
-                return Err(DecodeError::MissingField("PublicKey::pub_edward"))
-            };
-        let pub_curve =
-            if let Some(pc) = from_ed25519_pk(&pub_edward).map(ecdh::GroupElement) {
-                pc
-            } else {
-                return Err(DecodeError::InvalidField("PublicKey::pub_edward"))
-            };
+        let pub_edward = pub_edward.ok_or(DecodeError::MissingField("PublicKey::pub_edward"))?;
+        let pub_curve  = from_ed25519_pk(&pub_edward)
+            .map(ecdh::GroupElement)
+            .map_err(|()| DecodeError::InvalidField("PublicKey::pub_edward"))?;
         Ok(PublicKey {
             pub_edward: pub_edward,
             pub_curve:  pub_curve
@@ -528,24 +529,24 @@ impl Signature {
 
 // Internal /////////////////////////////////////////////////////////////////
 
-pub fn from_ed25519_pk(k: &sign::PublicKey) -> Option<[u8; ecdh::GROUPELEMENTBYTES]> {
+pub fn from_ed25519_pk(k: &sign::PublicKey) -> Result<[u8; ecdh::GROUPELEMENTBYTES], ()> {
     let mut ep = [0u8; ecdh::GROUPELEMENTBYTES];
     unsafe {
         if ffi::crypto_sign_ed25519_pk_to_curve25519(ep.as_mut_ptr(), (&k.0).as_ptr()) == 0 {
-            Some(ep)
+            Ok(ep)
         } else {
-            None
+            Err(())
         }
     }
 }
 
-pub fn from_ed25519_sk(k: &sign::SecretKey) -> Option<[u8; ecdh::SCALARBYTES]> {
+pub fn from_ed25519_sk(k: &sign::SecretKey) -> Result<[u8; ecdh::SCALARBYTES], ()> {
     let mut es = [0u8; ecdh::SCALARBYTES];
     unsafe {
         if ffi::crypto_sign_ed25519_sk_to_curve25519(es.as_mut_ptr(), (&k.0).as_ptr()) == 0 {
-            Some(es)
+            Ok(es)
         } else {
-            None
+            Err(())
         }
     }
 }
@@ -617,5 +618,14 @@ mod tests {
         assert_eq!(b, r);
         assert_eq!(PreKeyAuth::Valid, b.verify());
         assert_eq!(PreKeyAuth::Valid, r.verify());
+    }
+
+    #[test]
+    fn degenerated_key() {
+        let mut k = KeyPair::new();
+        for i in 0 .. k.public_key.pub_curve.0.len() {
+            k.public_key.pub_curve.0[i] = 0
+        }
+        assert_eq!(Err(Zero()), k.secret_key.shared_secret(&k.public_key))
     }
 }

--- a/src/internal/types.rs
+++ b/src/internal/types.rs
@@ -93,7 +93,8 @@ pub enum DecodeError {
     InvalidArrayLen(usize),
     LocalIdentityChanged(IdentityKey),
     InvalidType(u8, &'static str),
-    MissingField(&'static str)
+    MissingField(&'static str),
+    InvalidField(&'static str)
 }
 
 impl fmt::Display for DecodeError {
@@ -103,7 +104,8 @@ impl fmt::Display for DecodeError {
             DecodeError::InvalidArrayLen(n)      => write!(f, "CBOR array length mismatch: {}", n),
             DecodeError::LocalIdentityChanged(_) => write!(f, "Local identity changed"),
             DecodeError::InvalidType(t, ref s)   => write!(f, "Invalid type {}: {}", t, s),
-            DecodeError::MissingField(ref s)     => write!(f, "Missing field: {}", s)
+            DecodeError::MissingField(ref s)     => write!(f, "Missing field: {}", s),
+            DecodeError::InvalidField(ref s)     => write!(f, "Invalid field: {}", s)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,8 @@ pub mod keys;
 pub mod session;
 pub mod message;
 
-pub fn init() {
-    sodiumoxide::init();
+pub fn init() -> bool {
+    sodiumoxide::init()
 }
 
 pub use internal::types::{DecodeError, EncodeError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate cbor;
 extern crate byteorder;
 extern crate hkdf;
 extern crate libc;
+extern crate libsodium_sys;
 extern crate sodiumoxide;
 
 pub mod internal;

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,6 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+pub use internal::session::Error;
 pub use internal::session::PreKeyStore;
 pub use internal::session::Session;
-pub use internal::session::DecryptError;


### PR DESCRIPTION
This PR includes a number of changes:

- The `IdentityKeyPair` in `Session` is now `Borrow`ed instead of being fixed to plain references.
- The return codes of ed25519 to curve25519 conversions of keys are no longer ignored.
- The return code of `sodium::init` is no longer ignored.
- A custom wrapper to libsodium's `crypto_scalarmult_curve25519` function is used instead of sodiumoxide's `scalarmult`. The custom wrapper does not ignore the return code of `crypto_scalarmult_curve25519` which―if not 0―indicates that the resulting value is a null vector.
- `proteus::session::DecryptError` is renamed to `proteus::session::Error` since some error cases are not directly scoped to decryption.