### PR TITLE
Use more efficient bytestring decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license      = "GPL-3.0"
 
 [dependencies]
 byteorder     = ">  0.2.0"
-cbor-codec    = ">= 0.1.0"
+cbor-codec    = ">= 0.7.0"
 hkdf          = { git = "https://github.com/wireapp/hkdf", branch = "develop"}
 libc          = ">  0.1.0"
 libsodium-sys = ">= 0.0.12"

--- a/src/internal/util.rs
+++ b/src/internal/util.rs
@@ -60,13 +60,10 @@ pub struct Bytes32 { pub array: [u8; 32] }
 
 impl Bytes32 {
     pub fn decode<R: Read>(d: &mut Decoder<R>) -> DecodeResult<Bytes32> {
-        let v = d.bytes()?;
-        if 32 != v.len() {
-            return Err(DecodeError::InvalidArrayLen(v.len()))
-        }
         let mut a = [0u8; 32];
-        for i in 0..32 {
-            a[i] = v[i]
+        let n = d.read_bytes(&mut a)?;
+        if 32 != n {
+            return Err(DecodeError::InvalidArrayLen(n))
         }
         Ok(Bytes32 { array: a })
     }
@@ -78,13 +75,10 @@ pub struct Bytes64 { pub array: [u8; 64] }
 
 impl Bytes64 {
     pub fn decode<R: Read>(d: &mut Decoder<R>) -> DecodeResult<Bytes64> {
-        let v = d.bytes()?;
-        if 64 != v.len() {
-            return Err(DecodeError::InvalidArrayLen(v.len()))
-        }
         let mut a = [0u8; 64];
-        for i in 0..64 {
-            a[i] = v[i]
+        let n = d.read_bytes(&mut a)?;
+        if 64 != n {
+            return Err(DecodeError::InvalidArrayLen(n))
         }
         Ok(Bytes64 { array: a })
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -25,6 +25,7 @@ pub use internal::keys::MAX_PREKEY_ID;
 pub use internal::keys::PreKeyAuth;
 pub use internal::keys::PreKeyBundle;
 pub use internal::keys::Signature;
+pub use internal::keys::Zero;
 
 pub use internal::keys::gen_prekeys;
 pub use internal::keys::rand_bytes;


### PR DESCRIPTION
Also re-export `keys::Zero` und require cbor-codec >= 0.7