### PR TITLE
Pass `std` feature for libsodium

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ byteorder     = ">  0.2.0"
 cbor-codec    = ">= 0.7.0"
 hkdf          = { git = "https://github.com/wireapp/hkdf", branch = "develop"}
 libc          = ">  0.1.0"
-sodiumoxide   = { version = ">= 0.0.14", default-features = false }
+sodiumoxide   = { version = ">= 0.0.14", default-features = false, features = ["std"] }
 


### PR DESCRIPTION
Makes libsodium available on stable and thus Proteus building on stable.