### PR TITLE
Add travis badge, fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: rust
-rust: nightly
+rust:
+  - stable
+  - beta
+  - nightly
 
 before_script:
-    - wget "https://github.com/jedisct1/libsodium/releases/download/1.0.3/libsodium-1.0.3.tar.gz"
-    - tar -xzvf libsodium-1.0.3.tar.gz
-    - cd libsodium-1.0.3 && ./configure --prefix=/usr && make && sudo make install
+  - wget "https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz"
+  - tar -xzvf libsodium-1.0.16.tar.gz
+  - cd libsodium-1.0.16 && ./configure --prefix=/usr && make && sudo make install
+
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,5 +1,7 @@
 # Wire
 
+image:https://travis-ci.org/wireapp/proteus.svg?branch=master["Build Status", link="https://travis-ci.org/wireapp/proteus"]
+
 This repository is part of the source code of Wire. You can find more information at https://wire.com[wire.com] or by contacting opensource@wire.com.
 
 You can find the published source code at https://github.com/wireapp[github.com/wireapp].


### PR DESCRIPTION
This fixes the travis build and adds a build status badge to the readme. Rust nightly is built as well, but is allowed to fail.