### PR TITLE
refactor: `PreKeyStore` does not require mutable self references [WPB-25640]

### DIFF
--- a/crates/proteus-traits/src/lib.rs
+++ b/crates/proteus-traits/src/lib.rs
@@ -81,8 +81,8 @@ pub trait PreKeyStore {
     type Error: ProteusErrorCode;
 
     /// Lookup prekey by ID.
-    async fn prekey(&mut self, id: RawPreKeyId) -> Result<Option<RawPreKey>, Self::Error>;
+    async fn prekey(&self, id: RawPreKeyId) -> Result<Option<RawPreKey>, Self::Error>;
 
     /// Remove prekey by ID.
-    async fn remove(&mut self, id: RawPreKeyId) -> Result<(), Self::Error>;
+    async fn remove(&self, id: RawPreKeyId) -> Result<(), Self::Error>;
 }

--- a/src/internal/keys.rs
+++ b/src/internal/keys.rs
@@ -222,13 +222,11 @@ impl PreKey {
     }
 }
 
-#[must_use]
-pub fn gen_prekeys(start: PreKeyId, size: u16) -> Vec<PreKey> {
-    (1..)
-        .map(|i| (u32::from(start.value()) + i) % u32::from(MAX_PREKEY_ID.value()))
-        .map(|i| PreKey::new(PreKeyId::new(i as u16)))
-        .take(size as usize)
-        .collect()
+pub fn gen_prekeys(start: PreKeyId, size: u16) -> impl Iterator<Item = PreKey> {
+    (1..=size).map(move |i| {
+        let id = (start.value() as u32 + i as u32) % MAX_PREKEY_ID.value() as u32;
+        PreKey::new(PreKeyId::new(id as _))
+    })
 }
 
 // Prekey bundle ////////////////////////////////////////////////////////////
@@ -751,7 +749,6 @@ mod tests {
     #[wasm_bindgen_test]
     fn prekey_generation() {
         let k = gen_prekeys(PreKeyId::new(0xFFFC), 5)
-            .iter()
             .map(|k| k.key_id.value())
             .collect::<Vec<_>>();
         assert_eq!(vec![0xFFFD, 0xFFFE, 0, 1, 2], k)

--- a/src/internal/session.rs
+++ b/src/internal/session.rs
@@ -605,7 +605,8 @@ impl<I: Borrow<IdentityKeyPair>> Session<I> {
                 alice_ident: &m.identity_key,
                 alice_base: &m.base_key,
             })
-            .map(Some)} else {
+            .map(Some)
+        } else {
             Ok(None)
         }
     }
@@ -1084,6 +1085,7 @@ mod tests {
     use std::borrow::Borrow;
     use std::collections::BTreeMap;
     use std::fmt;
+    use std::sync::{Mutex, MutexGuard};
     use std::vec::Vec;
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -1098,14 +1100,14 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct TestStore {
-        prekeys: Vec<PreKey>,
+        prekeys: Mutex<Vec<PreKey>>,
     }
 
     impl TestStore {
-        pub fn prekey_slice(&self) -> &[PreKey] {
-            &self.prekeys
+        pub fn lock(&self) -> MutexGuard<'_, Vec<PreKey>> {
+            self.prekeys.lock().expect("propagate any mutex poison")
         }
     }
 
@@ -1115,22 +1117,34 @@ mod tests {
         type Error = DummyError;
 
         async fn prekey(
-            &mut self,
+            &self,
             id: proteus_traits::RawPreKeyId,
         ) -> Result<Option<proteus_traits::RawPreKey>, Self::Error> {
-            if let Some(prekey) = self.prekeys.iter().find(|k| k.key_id.value() == id) {
-                Ok(Some(prekey.serialise().unwrap()))
-            } else {
-                Ok(None)
-            }
+            self.lock()
+                .iter()
+                .find(|k| k.key_id.value() == id)
+                .map(|prekey| Ok(prekey.serialise().unwrap()))
+                .transpose()
         }
 
-        async fn remove(&mut self, id: proteus_traits::RawPreKeyId) -> Result<(), Self::Error> {
-            self.prekeys
+        async fn remove(&self, id: proteus_traits::RawPreKeyId) -> Result<(), Self::Error> {
+            let mut guard = self.lock();
+            guard
                 .iter()
                 .position(|k| k.key_id.value() == id)
-                .map(|ix| self.prekeys.swap_remove(ix));
+                .map(|ix| guard.swap_remove(ix));
             Ok(())
+        }
+    }
+
+    impl FromIterator<PreKey> for TestStore {
+        fn from_iter<I: IntoIterator<Item = PreKey>>(iter: I) -> Self {
+            let store = TestStore::default();
+            {
+                let mut guard = store.lock();
+                guard.extend(iter);
+            }
+            store
         }
     }
 
@@ -1147,12 +1161,10 @@ mod tests {
 
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), total_size as u16),
-        };
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), total_size as u16).collect::<TestStore>();
 
         let mut alices = Vec::new();
-        for pk in bob_store.prekey_slice() {
+        for pk in bob_store.lock().iter() {
             let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), pk);
             alices.push(Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap());
         }
@@ -1193,14 +1205,10 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut alice_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut alice_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
         let mut alice = Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap();
@@ -1340,14 +1348,10 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut alice_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut alice_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
         let mut alice = Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap();
@@ -1441,11 +1445,9 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
         let mut alice = Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap();
@@ -1474,17 +1476,13 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut alice_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut alice_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
-        let alice_prekey = alice_store.prekey_slice().first().unwrap().clone();
+        let alice_prekey = alice_store.lock().first().unwrap().clone();
         let alice_bundle = PreKeyBundle::new(alice_ident.public_key.clone(), &alice_prekey);
 
         // Initial simultaneous prekey message
@@ -1524,17 +1522,13 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut alice_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut alice_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
-        let alice_prekey = alice_store.prekey_slice().first().unwrap().clone();
+        let alice_prekey = alice_store.lock().first().unwrap().clone();
         let alice_bundle = PreKeyBundle::new(alice_ident.public_key.clone(), &alice_prekey);
 
         // Initial simultaneous prekey message
@@ -1598,11 +1592,9 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key, &bob_prekey);
 
         let alice = Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap();
@@ -1620,14 +1612,10 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut alice_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut alice_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
         let mut alice = Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap();
@@ -1682,11 +1670,9 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
         let mut alice = Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap();
@@ -1709,14 +1695,10 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut alice_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let mut alice_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle = PreKeyBundle::new(bob_ident.public_key.clone(), &bob_prekey);
 
         let mut alice = Session::init_from_prekey::<()>(&alice_ident, bob_bundle).unwrap();
@@ -1828,11 +1810,9 @@ mod tests {
         let bob_ident = IdentityKeyPair::new();
         let eve_ident = IdentityKeyPair::new();
 
-        let eve_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
+        let eve_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
 
-        let eve_prekey = eve_store.prekey_slice().first().unwrap().clone();
+        let eve_prekey = eve_store.lock().first().unwrap().clone();
         let mut eve_bundle = PreKeyBundle::new(eve_ident.public_key.clone(), &eve_prekey);
         let mut eve_bundle_signed = PreKeyBundle::signed(&eve_ident, &eve_prekey);
 
@@ -1846,10 +1826,8 @@ mod tests {
         assert_eq!(PreKeyAuth::Invalid, eve_bundle_signed.verify());
 
         // authentic prekey
-        let bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 10),
-        };
-        let bob_prekey = bob_store.prekey_slice().first().unwrap().clone();
+        let bob_store = gen_prekeys(PreKeyId::new(0), 10).collect::<TestStore>();
+        let bob_prekey = bob_store.lock().first().unwrap().clone();
         let bob_bundle_signed = PreKeyBundle::signed(&bob_ident, &bob_prekey);
         assert_eq!(PreKeyAuth::Valid, bob_bundle_signed.verify());
     }
@@ -1860,9 +1838,7 @@ mod tests {
         let alice = IdentityKeyPair::new();
         let bob = IdentityKeyPair::new();
 
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 500),
-        };
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 500).collect::<TestStore>();
 
         async fn get_bob(bob: &IdentityKeyPair, i: u16, store: &mut TestStore) -> PreKeyBundle {
             PreKeyBundle::new(
@@ -1927,13 +1903,9 @@ mod tests {
         let alice = IdentityKeyPair::new();
         let bob = IdentityKeyPair::new();
 
-        let mut bob_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(0), 1),
-        };
+        let mut bob_store = gen_prekeys(PreKeyId::new(0), 1).collect::<TestStore>();
 
-        let mut alice_store = TestStore {
-            prekeys: gen_prekeys(PreKeyId::new(1), 1),
-        };
+        let mut alice_store = gen_prekeys(PreKeyId::new(1), 1).collect::<TestStore>();
 
         async fn get_bob(bob: &IdentityKeyPair, i: u16, store: &mut TestStore) -> PreKeyBundle {
             PreKeyBundle::new(
@@ -2007,12 +1979,12 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut bob_store1 = TestStore {
-            prekeys: vec![PreKey::new(PreKeyId::new(1))],
-        };
-        let mut bob_store2 = TestStore {
-            prekeys: vec![PreKey::new(PreKeyId::new(1))],
-        };
+        let mut bob_store1 = [PreKey::new(PreKeyId::new(1))]
+            .into_iter()
+            .collect::<TestStore>();
+        let mut bob_store2 = [PreKey::new(PreKeyId::new(1))]
+            .into_iter()
+            .collect::<TestStore>();
 
         let bob_prekey = PreKey::deserialise(
             &bob_store1
@@ -2053,9 +2025,7 @@ mod tests {
         let alice_ident = IdentityKeyPair::new();
         let bob_ident = IdentityKeyPair::new();
 
-        let mut bob_store = TestStore {
-            prekeys: vec![PreKey::last_resort()],
-        };
+        let mut bob_store = [PreKey::last_resort()].into_iter().collect::<TestStore>();
 
         let bob_prekey = PreKey::deserialise(
             &bob_store

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #![allow(dead_code)]
 
+use std::sync::{Mutex, MutexGuard};
+
 pub const MSG: &[u8] = b"Hello world!";
 
 #[derive(Debug, PartialEq)]
@@ -28,24 +30,32 @@ impl proteus_traits::ProteusErrorCode for DummyError {
 }
 
 #[derive(Debug)]
-pub struct PrekeyStore<T>(pub Vec<T>);
+pub struct PrekeyStore<T>(Mutex<Vec<T>>);
 
+// manual impl so as not to impose a `T: Default` bound
 impl<T> Default for PrekeyStore<T> {
     fn default() -> Self {
-        Self(vec![])
+        Self(Default::default())
     }
 }
 
-impl<T> std::ops::Deref for PrekeyStore<T> {
-    type Target = Vec<T>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl<T> FromIterator<T> for PrekeyStore<T> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let store = Self::default();
+        {
+            let mut guard = store.lock();
+            guard.extend(iter);
+        }
+        store
     }
 }
 
-impl<T> std::ops::DerefMut for PrekeyStore<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+impl<T> PrekeyStore<T> {
+    pub fn lock(&self) -> MutexGuard<'_, Vec<T>> {
+        self.0.lock().expect("propagate any mutex lock poison")
     }
 }
 
@@ -57,14 +67,15 @@ impl proteus::session::PreKeyStore for PrekeyStore<proteus::keys::PreKey> {
         &mut self,
         id: proteus::keys::PreKeyId,
     ) -> Result<Option<proteus::keys::PreKey>, Self::Error> {
-        Ok(self.0.iter().find(|k| k.key_id == id).cloned())
+        Ok(self.lock().iter().find(|k| k.key_id == id).cloned())
     }
 
     fn remove(&mut self, id: proteus::keys::PreKeyId) -> Result<(), Self::Error> {
-        self.0
+        let mut guard = self.lock();
+        guard
             .iter()
             .position(|k| k.key_id.value() == id.value())
-            .map(|idx| self.0.swap_remove(idx));
+            .map(|idx| guard.swap_remove(idx));
 
         Ok(())
     }
@@ -76,21 +87,22 @@ impl proteus_traits::PreKeyStore for PrekeyStore<proteus_wasm::keys::PreKey> {
     type Error = DummyError;
 
     async fn prekey(
-        &mut self,
+        &self,
         id: proteus_traits::RawPreKeyId,
     ) -> Result<Option<proteus_traits::RawPreKey>, Self::Error> {
         Ok(self
-            .0
+            .lock()
             .iter()
             .find(|k| k.key_id.value() == id)
             .map(|pk| proteus_wasm::keys::PreKey::serialise(pk).unwrap()))
     }
 
-    async fn remove(&mut self, id: proteus_traits::RawPreKeyId) -> Result<(), Self::Error> {
-        self.0
+    async fn remove(&self, id: proteus_traits::RawPreKeyId) -> Result<(), Self::Error> {
+        let mut guard = self.lock();
+        guard
             .iter()
             .position(|k| k.key_id.value() == id)
-            .map(|idx| self.0.swap_remove(idx));
+            .map(|idx| guard.swap_remove(idx));
 
         Ok(())
     }
@@ -169,24 +181,26 @@ macro_rules! impl_harness_for_crate {
             }
 
             pub fn new_prekey(&mut self) -> $target::keys::PreKeyBundle {
-                let prekey_id = (self.prekeys.len() + 1 % u16::MAX as usize) as u16;
+                let mut store_guard = self.prekeys.lock();
+                let prekey_id = (store_guard.len() + 1 % u16::MAX as usize) as u16;
                 let prekey = $target::keys::PreKey::new($target::keys::PreKeyId::new(prekey_id));
                 let prekey_bundle =
                     $target::keys::PreKeyBundle::new(self.identity.public_key.clone(), &prekey);
-                self.prekeys.push(prekey);
+                store_guard.push(prekey);
                 prekey_bundle
             }
 
             pub fn new_prekey_with_id(&mut self, prekey_id: u16) -> $target::keys::PreKeyBundle {
+                let mut store_guard = self.prekeys.lock();
                 let prekey = $target::keys::PreKey::new($target::keys::PreKeyId::new(prekey_id));
                 let prekey_bundle =
                     $target::keys::PreKeyBundle::new(self.identity.public_key.clone(), &prekey);
-                self.prekeys.push(prekey);
+                store_guard.push(prekey);
                 prekey_bundle
             }
 
             pub fn get_prekey_bundle(&self, index: usize) -> $target::keys::PreKeyBundle {
-                let prekey = &self.prekeys[index];
+                let prekey = &self.prekeys.lock()[index];
                 let prekey_bundle =
                     $target::keys::PreKeyBundle::new(self.identity.public_key.clone(), prekey);
                 prekey_bundle
@@ -205,12 +219,12 @@ impl Client {
         let identity =
             proteus::keys::IdentityKeyPair::deserialise(&self.identity.serialise().unwrap())
                 .unwrap();
-        let prekeys = PrekeyStore(
-            self.prekeys
-                .iter()
-                .map(|pk| proteus::keys::PreKey::deserialise(&pk.serialise().unwrap()).unwrap())
-                .collect(),
-        );
+        let prekeys = self
+            .prekeys
+            .lock()
+            .iter()
+            .map(|pk| proteus::keys::PreKey::deserialise(&pk.serialise().unwrap()).unwrap())
+            .collect();
 
         let sessions = self
             .sessions
@@ -288,14 +302,12 @@ impl LegacyClient {
         let identity =
             proteus_wasm::keys::IdentityKeyPair::deserialise(&self.identity.serialise().unwrap())
                 .unwrap();
-        let prekeys = PrekeyStore(
-            self.prekeys
-                .iter()
-                .map(|pk| {
-                    proteus_wasm::keys::PreKey::deserialise(&pk.serialise().unwrap()).unwrap()
-                })
-                .collect(),
-        );
+        let prekeys = self
+            .prekeys
+            .lock()
+            .iter()
+            .map(|pk| proteus_wasm::keys::PreKey::deserialise(&pk.serialise().unwrap()).unwrap())
+            .collect();
 
         let sessions = self
             .sessions

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -33,20 +33,21 @@ mod serialization {
         sk.copy_from_slice(&alice_legacy.identity.secret_key.as_slice()[..64]);
         let mut pk = [0u8; 32];
         pk.copy_from_slice(&alice_legacy.identity.public_key.public_key.as_slice()[..32]);
-        let mut alice = Client::from_raw(sk, pk);
+        let alice = Client::from_raw(sk, pk);
 
         for _ in 0..10 {
             alice_legacy.new_prekey();
         }
 
-        let alice_legacy_prekeys = alice_legacy
+        for pk in alice_legacy
             .prekeys
+            .lock()
             .iter()
-            .map(|pk| pk.serialise().unwrap());
-
-        for pk in alice_legacy_prekeys {
+            .map(|pk| pk.serialise().unwrap())
+        {
             alice
                 .prekeys
+                .lock()
                 .push(proteus_wasm::keys::PreKey::deserialise(&pk).unwrap());
         }
 
@@ -120,8 +121,8 @@ mod serialization {
     fn serialize_interop_prekey() {
         let (alice, alice_legacy) = get_client_pair();
 
-        let prekey = &alice.prekeys[0];
-        let prekey_legacy = &alice_legacy.prekeys[0];
+        let prekey = &alice.prekeys.lock()[0];
+        let prekey_legacy = &alice_legacy.prekeys.lock()[0];
 
         // Check if prekeys serialize the same
         assert_eq!(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³
