### PR TITLE
chore: session methods do not require a mutable ref to keystore

### DIFF
--- a/src/internal/session.rs
+++ b/src/internal/session.rs
@@ -473,7 +473,7 @@ impl<I: Borrow<IdentityKeyPair>> Session<I> {
     #[allow(clippy::type_complexity)]
     pub async fn init_from_message<S: proteus_traits::PreKeyStore>(
         ours: I,
-        store: &mut S,
+        store: &S,
         env: &Envelope<'_>,
     ) -> SessionResult<(Session<I>, Vec<u8>), S::Error> {
         let Message::Keyed(pkmsg) = env.message() else {
@@ -533,7 +533,7 @@ impl<I: Borrow<IdentityKeyPair>> Session<I> {
 
     pub async fn decrypt<S: PreKeyStore>(
         &mut self,
-        store: &mut S,
+        store: &S,
         env: &Envelope<'_>,
     ) -> SessionResult<Vec<u8>, S::Error> {
         match *env.message() {
@@ -588,7 +588,7 @@ impl<I: Borrow<IdentityKeyPair>> Session<I> {
     // See note [no_new_state] for those cases where no prekey has been found.
     async fn new_state<S: proteus_traits::PreKeyStore>(
         &self,
-        store: &mut S,
+        store: &S,
         m: &PreKeyMessage<'_>,
     ) -> SessionResult<Option<SessionState>, S::Error> {
         let prekey_raw = store


### PR DESCRIPTION
As the `PreKeyStore` trait methods no longer require mutable self references, the `Session` methods also no longer require mutable keystore references.

Technically this is a breaking change but really it's just finishing the changes introduced by 3.0.0

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³
